### PR TITLE
CP-43 - Upgrade Checkpoint to 1.1.0 and update Agent Resolver

### DIFF
--- a/kcv.gemspec
+++ b/kcv.gemspec
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
@@ -26,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "checkpoint", "~> 1.0.3"
+  spec.add_dependency "checkpoint", "~> 1.1.0"
   spec.add_dependency "keycard", "~> 0.2.4"
   spec.add_dependency "vizier", "~> 0.1.0"
 

--- a/lib/kcv/version.rb
+++ b/lib/kcv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KCV
-  VERSION = "0.2.4"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
The base Agent Resolver now has expansion and conversion separated, so
we have to implement the new interface here. With conversion upstreamed,
the implementation is simplified considerably.